### PR TITLE
Adding contact note recording

### DIFF
--- a/app/assets/stylesheets/advisors.sass
+++ b/app/assets/stylesheets/advisors.sass
@@ -52,6 +52,13 @@
         border: 0
 
 
+a[data-icon='envelope']
+  &::after
+    visibility: visible
+    content: '\f0e0'
+    font-family: 'FontAwesome'
+    margin-left: 0.5em
+
 #clients_needing_appointment
   background-color: $red
   padding: 0.5rem 1.5rem
@@ -60,12 +67,6 @@
     display: none
   table
     margin-bottom: 0
-    td.email a[data-icon='envelope']
-      &::after
-        visibility: visible
-        content: '\f0e0'
-        font-family: 'FontAwesome'
-        margin-left: 0.5em
   h4
     text-align: center
     color: $white

--- a/app/controllers/advisor/contact_notes_controller.rb
+++ b/app/controllers/advisor/contact_notes_controller.rb
@@ -1,0 +1,29 @@
+class Advisor::ContactNotesController < Advisor::BaseController
+
+  expose :client, decorate: ->(client){ client.decorate }
+  expose :contact_note
+  expose :new_contact_note, -> { client.contact_notes.build(advisor_id: current_advisor.id, contact_method: client.preferred_contact_method) }
+
+  def new
+  end
+
+  def create
+    if contact_note.save
+      flash[:success] = "Contact Nor saved saved"
+      redirect_to :advisor_my_clients
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def contact_note_params
+    params.require(:contact_note).permit(
+      :advisor_id,
+      :client_id,
+      :content,
+      :contact_method)
+  end
+
+end

--- a/app/controllers/advisor/contact_notes_controller.rb
+++ b/app/controllers/advisor/contact_notes_controller.rb
@@ -1,17 +1,18 @@
 class Advisor::ContactNotesController < Advisor::BaseController
 
   expose :client, decorate: ->(client){ client.decorate }
+
   expose :contact_note
-  expose :new_contact_note, -> { client.contact_notes.build(advisor_id: current_advisor.id, contact_method: client.preferred_contact_method) }
 
   def new
+    init_contact_note
   end
 
   def create
     if contact_note.save
-      flash[:success] = "Contact Nor saved saved"
       redirect_to :advisor_my_clients
     else
+      flash[:success] = "Failed to save contact"
       render :new
     end
   end
@@ -24,6 +25,12 @@ class Advisor::ContactNotesController < Advisor::BaseController
       :client_id,
       :content,
       :contact_method)
+  end
+
+  def init_contact_note
+    contact_note.advisor_id = current_advisor.id
+    contact_note.client_id = params[:client_id]
+    contact_note.contact_method = client.preferred_contact_method
   end
 
 end

--- a/app/controllers/advisor/meetings_controller.rb
+++ b/app/controllers/advisor/meetings_controller.rb
@@ -2,13 +2,14 @@ class Advisor::MeetingsController < Advisor::BaseController
 
   expose :client
   expose :meeting
-  expose :new_meeting, -> { client.meetings.build(advisor_id: current_advisor.id) }
 
   def index
   end
 
   def new
-    new_meeting.agenda = 'initial_assessment' if client.meetings.empty?
+    meeting.agenda = 'initial_assessment' if client.meetings.empty?
+    meeting.advisor_id = current_advisor.id
+    meeting.client_id = params[:client_id]
   end
 
   def edit

--- a/app/controllers/advisor/my_clients_controller.rb
+++ b/app/controllers/advisor/my_clients_controller.rb
@@ -1,7 +1,7 @@
 class Advisor::MyClientsController < Advisor::BaseController
 
   def index
-    @clients_needing_appointment = current_advisor.clients.needing_appointment.to_a
+    @clients_requiring_contact = current_advisor.clients.needing_contact.to_a
     init_filtered_clients
     respond_to do |format|
       format.html

--- a/app/decorators/client_decorator.rb
+++ b/app/decorators/client_decorator.rb
@@ -64,6 +64,22 @@ class ClientDecorator < Draper::Decorator
     standard_wrapper("Hours per week:", client.working_hours_per_week)
   end
 
+  def decorate_preferred_contact
+    if client.preferred_contact_method
+      h.content_tag(:span, "(Client prefers to be contacted by #{ContactMethodOption.find(client.preferred_contact_method)})") << phone_span << email_link
+    else
+      phone_span << email_link
+    end
+  end
+
+  def phone_span
+    h.content_tag(:p, client.phone_number)
+  end
+
+  def email_link
+    h.content_tag(:p, h.mail_to(client.email, 'Email ', data: {'icon': 'envelope'}))
+  end
+
   def new_file_button
     # h.link_to I18n.t('clients.buttons.upload_cv'), h.new_client_file_upload_path(client), class: "button is-primary is-small"
   end

--- a/app/lib/contact_method_option.rb
+++ b/app/lib/contact_method_option.rb
@@ -10,7 +10,8 @@ class ContactMethodOption
   def self.all
     [
       new('Email'),
-      new('Phone call')
+      new('Phone call'),
+      new('Hub visit')
     ]
   end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -16,11 +16,11 @@ class Client < ApplicationRecord
 
   has_many :meetings
 
-  scope :needing_contact, -> { needing_appointment.where('contact_notes_count < 3 ').order(contact_notes_count: :asc, created_at: :asc) }
+  scope :needing_contact, -> { needing_appointment.order(contact_notes_count: :asc, created_at: :asc) }
 
   scope :needing_appointment, -> { where(meetings_count: 0) }
 
-  scope :with_appointment, -> { where('meetings_count > 0 OR contact_notes_count > 3') }
+  scope :with_appointment, -> { where('meetings_count > 0') }
 
   accepts_nested_attributes_for :login
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -16,10 +16,11 @@ class Client < ApplicationRecord
 
   has_many :meetings
 
-  scope :needing_contact, -> { needing_appointment.where('contact_notes_count < 0 ').order(contact_notes_count: :asc) }
+  scope :needing_contact, -> { needing_appointment.where('contact_notes_count < 3 ').order(contact_notes_count: :asc, created_at: :asc) }
 
-  scope :needing_appointment, -> { where(meetings_count: 0).order(created_at: :asc) }
-  scope :with_appointment, -> { where('meetings_count > 0') }
+  scope :needing_appointment, -> { where(meetings_count: 0) }
+
+  scope :with_appointment, -> { where('meetings_count > 0 OR contact_notes_count > 3') }
 
   accepts_nested_attributes_for :login
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -16,6 +16,8 @@ class Client < ApplicationRecord
 
   has_many :meetings
 
+  scope :needing_contact, -> { needing_appointment.where('contact_notes_count < 0 ').order(contact_notes_count: :asc) }
+
   scope :needing_appointment, -> { where(meetings_count: 0).order(created_at: :asc) }
   scope :with_appointment, -> { where('meetings_count > 0') }
 
@@ -33,6 +35,7 @@ class Client < ApplicationRecord
   validates_plausible_phone :phone, country_code: 'GB'
 
   has_many :assessment_notes
+  has_many :contact_notes
 
   accepts_nested_attributes_for :assessment_notes, reject_if: :all_blank
 

--- a/app/models/contact_note.rb
+++ b/app/models/contact_note.rb
@@ -1,0 +1,11 @@
+class ContactNote < ApplicationRecord
+
+  belongs_to :client, counter_cache: true
+  belongs_to :advisor
+
+  validates :client_id, :advisor_id, :content, presence: true
+
+  def contact_date
+    self.created_at.to_date.to_s(:short)
+  end
+end

--- a/app/views/advisor/contact_notes/new.html.haml
+++ b/app/views/advisor/contact_notes/new.html.haml
@@ -11,7 +11,9 @@
 
   %p Or make a note that you made contact or tried contacting your client
 
-  = simple_form_for [client, new_contact_note], url: advisor_client_contact_notes_path(client_id: client.id) do |form|
+  = simple_form_for [client, contact_note], url: advisor_client_contact_notes_path(client_id: client.id) do |form|
+
+    = render 'shared/form_errors', object: form.object
 
     %fieldset
       .convert_radio

--- a/app/views/advisor/contact_notes/new.html.haml
+++ b/app/views/advisor/contact_notes/new.html.haml
@@ -1,0 +1,26 @@
+.column.is-10.is-offset-1
+
+  %h3.subtitle="Contacting #{client.name}"
+  %p=client.decorate_preferred_contact
+  %hr
+
+  %p If you scheduled a meeting click here instead
+  =button_to I18n.t('clients.buttons.arrange_meeting'), new_advisor_client_meeting_path(client), method: :get, class: "button is-primary is-small"
+
+  %br
+
+  %p Or make a note that you made contact or tried contacting your client
+
+  = simple_form_for [client, new_contact_note], url: advisor_client_contact_notes_path(client_id: client.id) do |form|
+
+    %fieldset
+      .convert_radio
+        =form.input :contact_method, as: :radio_buttons, collection: ContactMethodOption.all, :label => 'How did you communicate with them?', include_hidden: false
+
+      =form.input :content, as: :text, :input_html => { :class => "textarea" }
+
+      =form.input :client_id, as: :hidden
+      =form.input :advisor_id, as: :hidden
+
+    .control
+      = form.submit I18n.t('clients.buttons.save'), :class => 'button is-primary'

--- a/app/views/advisor/meetings/new.html.haml
+++ b/app/views/advisor/meetings/new.html.haml
@@ -3,7 +3,7 @@
   %hr
   %p Please record the date your meeting
 
-  = simple_form_for [client, new_meeting], url: advisor_client_meetings_path(client_id: client.id) do |form|
+  = simple_form_for [client, meeting], url: advisor_client_meetings_path(client_id: client.id) do |form|
 
     = render partial: 'form_fields', locals: {form: form}
 

--- a/app/views/advisor/my_clients/_awaiting_contact.html.haml
+++ b/app/views/advisor/my_clients/_awaiting_contact.html.haml
@@ -1,0 +1,10 @@
+%tr[client]
+  %td=link_to client.name, edit_advisor_client_path(client)
+  %td.has-text-centered
+    =client.created_at.to_date.to_s(:short)
+    %span.bold=number_of_days_waiting(client.created_at.to_date)
+  %td.has-text-centered
+    ="#{pluralize(client.contact_notes_count, 'time')}"
+  %td.has-text-centered
+    =client.contact_notes.last.try(:contact_date)
+  %td.has-text-right=button_to I18n.t('clients.buttons.make_contact'), new_advisor_client_contact_note_path(client), method: :get, class: "button is-primary is-small"

--- a/app/views/advisor/my_clients/_needing_appointment.html.haml
+++ b/app/views/advisor/my_clients/_needing_appointment.html.haml
@@ -1,8 +1,0 @@
-%tr[client]
-  %td=link_to client.name, edit_advisor_client_path(client)
-  %td.has-text-centered
-    ="Registered: #{client.created_at.to_date.to_s(:short)}"
-    %span.bold=number_of_days_waiting(client.created_at.to_date)
-  %td.has-text-centered=client.phone_number
-  %td.has-text-centered.email=mail_to client.email, 'Email ', data: {'icon': 'envelope'}, class: 'icon'
-  %td.has-text-right=button_to I18n.t('clients.buttons.arrange_first_meeting'), new_advisor_client_meeting_path(client), method: :get, class: "button is-primary is-small"

--- a/app/views/advisor/my_clients/index.html.haml
+++ b/app/views/advisor/my_clients/index.html.haml
@@ -3,17 +3,17 @@
   .head.columns.level
     .level-left.column
       %h2 Your Clients
-      -if @clients_needing_appointment.any?
-        %span.client_total="#{current_advisor.clients.count} Total (#{@clients_needing_appointment.count} need initial contact)"
+      -if @clients_requiring_contact.any?
+        %span.client_total="#{current_advisor.clients.count} Total (#{@clients_requiring_contact.count} need initial contact)"
       -else
         %span.client_total="#{current_advisor.clients.count} Total"
 
-  -if @clients_needing_appointment.any?
+  -if @clients_requiring_contact.any?
     %section#clients_needing_appointment.hero.is-fullwidth.section
       .container.content.columns
         .column
           %h4.bold
-            ="You have #{pluralize(@clients_needing_appointment.count, 'client')} that still require initial contact"
+            ="You have #{pluralize(@clients_requiring_contact.count, 'client')} that still require initial contact"
 
           %table.table
             %thead
@@ -24,16 +24,16 @@
                 %th Last contact
                 %th
             %tbody
-              = render partial: 'awaiting_contact', collection: @clients_needing_appointment.shift(2), as: 'client'
+              = render partial: 'awaiting_contact', collection: @clients_requiring_contact.shift(2), as: 'client'
 
-          -if @clients_needing_appointment.any?
+          -if @clients_requiring_contact.any?
             %h4#view_more
-              ="View other #{pluralize((@clients_needing_appointment.count), 'client')}"
+              ="View other #{pluralize((@clients_requiring_contact.count), 'client')}"
               %i.fa.fa-chevron-down
             #hidden-section
               %table.table
                 %tbody
-                  = render partial: 'awaiting_contact', collection: @clients_needing_appointment, as: 'client'
+                  = render partial: 'awaiting_contact', collection: @clients_requiring_contact, as: 'client'
 
 
   - if @filterrific.model_class.any?

--- a/app/views/advisor/my_clients/index.html.haml
+++ b/app/views/advisor/my_clients/index.html.haml
@@ -16,8 +16,15 @@
             ="You have #{pluralize(@clients_needing_appointment.count, 'client')} that still require initial contact"
 
           %table.table
+            %thead
+              %tr
+                %th Client
+                %th Registered
+                %th Tried to contact
+                %th Last contact
+                %th
             %tbody
-              = render partial: 'needing_appointment', collection: @clients_needing_appointment.shift(2), as: 'client'
+              = render partial: 'awaiting_contact', collection: @clients_needing_appointment.shift(2), as: 'client'
 
           -if @clients_needing_appointment.any?
             %h4#view_more
@@ -26,7 +33,7 @@
             #hidden-section
               %table.table
                 %tbody
-                  = render partial: 'needing_appointment', collection: @clients_needing_appointment, as: 'client'
+                  = render partial: 'awaiting_contact', collection: @clients_needing_appointment, as: 'client'
 
 
   - if @filterrific.model_class.any?

--- a/config/locales/clients.en.yml
+++ b/config/locales/clients.en.yml
@@ -31,6 +31,7 @@ en:
     buttons:
       upload_cv: 'Upload CV'
       delete: 'Delete'
+      make_contact: "Make contact"
       arrange_meeting: "Schedule meeting"
       arrange_first_meeting: "Schedule initial meeting"
       assign_to_me: 'Assign to me'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ WaysIntoWork::Application.routes.draw do
       resources :file_uploads, only: [:create, :new, :destroy]
       resources :meetings
       resources :action_plan_tasks
+      resources :contact_notes, only: [:create, :new]
     end
 
     resources :my_clients, only: :index

--- a/db/migrate/20170714110205_create_contact_notes.rb
+++ b/db/migrate/20170714110205_create_contact_notes.rb
@@ -1,0 +1,12 @@
+class CreateContactNotes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :contact_notes do |t|
+      t.text :content
+      t.string :contact_method
+      t.belongs_to :advisor, index: true
+      t.belongs_to :client, index: true
+      t.timestamps
+    end
+    add_column :clients, :contact_notes_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170712170819) do
+ActiveRecord::Schema.define(version: 20170714110205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,7 +87,19 @@ ActiveRecord::Schema.define(version: 20170712170819) do
     t.string "bame"
     t.string "other_bame"
     t.string "barriers", default: [], array: true
+    t.integer "contact_notes_count", default: 0
     t.index ["advisor_id"], name: "index_clients_on_advisor_id"
+  end
+
+  create_table "contact_notes", force: :cascade do |t|
+    t.text "content"
+    t.string "contact_method"
+    t.bigint "advisor_id"
+    t.bigint "client_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["advisor_id"], name: "index_contact_notes_on_advisor_id"
+    t.index ["client_id"], name: "index_contact_notes_on_client_id"
   end
 
   create_table "file_uploads", force: :cascade do |t|

--- a/features/advisors/arranges_meeting.feature
+++ b/features/advisors/arranges_meeting.feature
@@ -13,4 +13,8 @@ Feature: Advisor records meeting arrangement
     And I schedule a meeting for next week with notes
     Then I should see the meeting has been booked
 
+  Scenario: Advisor records tried calling but no answer
+    Given I am on the advisor my clients page
+    And I record I tried calling but no asnswer
+    Then I should see the client has had contact made
 

--- a/features/step_definitions/meeting_steps.rb
+++ b/features/step_definitions/meeting_steps.rb
@@ -11,7 +11,8 @@ end
 World MeetingSH
 
 Given(/^I schedule a meeting for next week with notes$/) do
-  click_on I18n.t('clients.buttons.arrange_first_meeting')
+  click_on I18n.t('clients.buttons.make_contact')
+  click_on I18n.t('clients.buttons.arrange_meeting')
   meeting_date = Time.now + 3.days
   select meeting_date.year, from: 'meeting_start_datetime_1i'
   select Date::MONTHNAMES[meeting_date.month], from: 'meeting_start_datetime_2i'
@@ -29,3 +30,15 @@ Then(/^I should see the meeting has been booked$/) do
   end
 end
 
+Given(/^I record I tried calling but no asnswer$/) do
+  click_on I18n.t('clients.buttons.make_contact')
+  choose "contact_note_contact_method_phone_call"
+  fill_in 'contact_note_content', with: "tried calling and left a message"
+  click_on 'Save'
+end
+
+Then(/^I should see the client has had contact made$/) do
+  within "table tr#client_#{@client.id}" do
+    expect(page).to have_content('1 time')
+  end
+end


### PR DESCRIPTION
This feature is out of the requirement that advisors must attempt to
contact clients at least 3 times to arrange a meeting.

Allowing for traceability of attempting to contact a client. Will build
up
a timeline