### PR TITLE
Ce profile page

### DIFF
--- a/app/assets/stylesheets/advisors.sass
+++ b/app/assets/stylesheets/advisors.sass
@@ -102,6 +102,19 @@
       &.red
         color: $color__red
 
+#tab-list
+  ul
+    margin-top: 0
+    margin-left: 0
+  li
+    list-style-type: none
+    margin-bottom: 20px
+    padding-bottom: 5px
+
+  .ui-tabs-active a, a:hover
+    border-bottom: 2px solid $blue
+  a:focus, li:focus
+    outline: none
 
 #upper-tabs
   margin-bottom: 0
@@ -111,7 +124,7 @@
     text-transform: uppercase
     font-weight: $weight-medium
   .single-tab
-    padding: 15px 30px 18px 30px
+    padding: 15px 45px 18px 45px
     opacity: 0.5
     &:hover
       opacity: 1
@@ -131,6 +144,8 @@
   padding: 30px
   border-radius: 5px
   margin-top: -1px
+  .tab
+    padding-left: 15px
 
 .top-left-corner
   border-top-left-radius: 0px

--- a/app/assets/stylesheets/advisors.sass
+++ b/app/assets/stylesheets/advisors.sass
@@ -101,3 +101,38 @@
         color: $color__green
       &.red
         color: $color__red
+
+
+#upper-tabs
+  margin-bottom: 0
+  margin-top: 50px
+  a
+    color: $black
+    text-transform: uppercase
+    font-weight: $weight-medium
+  .single-tab
+    padding: 15px 30px 18px 30px
+    opacity: 0.5
+    &:hover
+      opacity: 1
+    &.current
+      opacity: 1
+      background-color: #fff
+      border-top-left-radius: 5px
+      border-top-right-radius: 5px
+      border: 1px rgba(29, 29, 27, 0.15) solid
+      border-bottom: none
+      &:hover
+        cursor: default
+
+.profile-tab
+  border: 1px rgba(29, 29, 27, 0.15) solid
+  background-color: #fff
+  padding: 30px
+  border-radius: 5px
+  margin-top: -1px
+
+.top-left-corner
+  border-top-left-radius: 0px
+.top-right-corner
+  border-top-right-radius: 0px

--- a/app/assets/stylesheets/utilities/initial-variables.sass
+++ b/app/assets/stylesheets/utilities/initial-variables.sass
@@ -50,14 +50,14 @@ $body-size: 16px !default
 
 // Responsiveness
 
-// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+// 960, 1152, and 1152 have been chosen because they are divisible by both 12 and 16
 $tablet: 769px !default
 // 960px container + 40px
-$desktop: 1000px !default
+$desktop: 960px !default
 // 1152px container + 40
-$widescreen: 1440px !default
+$widescreen: 1152px !default
 // 1440px container + 40
-$fullhd: 1480px !default
+$fullhd: 1152px !default
 
 // Miscellaneous
 

--- a/app/views/advisor/action_plan_tasks/_form_fields.html.haml
+++ b/app/views/advisor/action_plan_tasks/_form_fields.html.haml
@@ -1,7 +1,7 @@
 = render 'shared/form_errors', object: form.object
 %fieldset
-  = form.input :title, as: :string, label: "Agreed action:"
-  = form.input :notes, as: :text, label: "Notes"
+  = form.input :title, as: :string, label: "Agreed action:", :input_html => { :class => "input" }
+  = form.input :notes, as: :text, label: "Notes", :input_html => { :class => "textarea" }
   .convert_radio
     = form.input :advisor_id, as: :radio_buttons, label: "Action to be completed by:", collection: [['Client', ''], ['Advisor', current_advisor.id]]
 

--- a/app/views/advisor/action_plan_tasks/edit.html.haml
+++ b/app/views/advisor/action_plan_tasks/edit.html.haml
@@ -1,4 +1,4 @@
-%section.column.is-10.is-offset-1
+%section.column
   %h2= "Update details"
   = simple_form_for [action_plan_task.client, action_plan_task], url: advisor_client_action_plan_task_path(client_id: client.id, id: action_plan_task.id), method: :put do |form|
 

--- a/app/views/advisor/action_plan_tasks/index.html.haml
+++ b/app/views/advisor/action_plan_tasks/index.html.haml
@@ -1,38 +1,44 @@
 .column
-  =button_to I18n.t('clients.buttons.new_action_plan_task'), new_advisor_client_action_plan_task_path(client), method: :get, class: "button is-primary is-small"
-
   .head.level
     .level-left
-      %h2 Ongoing Actions
-      %span
-        =client.action_plan_tasks.ongoing.count
+      %h2="#{client.first_name}'s Ongoing Actions"
+      %span.client_total=client.action_plan_tasks.ongoing.count
 
-  - if client.action_plan_tasks.ongoing.any?
-    %section
-      %table.table
-        %thead
-          %tr
-            %th Agreed Action
-            %th Due Date
-            %th Action for
-            %th
-        %tbody
-          = render partial: 'ongoing_action', collection: client.action_plan_tasks.ongoing, as: 'action_plan_task'
+    .level-right
+      =button_to I18n.t('clients.buttons.new_action_plan_task'), new_advisor_client_action_plan_task_path(client), method: :get, class: "button is-primary"
 
-  .head.level
-    .level-left
-      %h2 Completed Actions
-      %span
-        =client.action_plan_tasks.completed.count
+  = render partial: 'shared/upper_tabs', locals: {the_client: client}
 
-  - if client.action_plan_tasks.completed.any?
-    %section
-      %table.table
-        %thead
-          %tr
-            %th Agreed Action
-            %th Completion Date
-            %th Action for
-            %th
-        %tbody
-          = render partial: 'completed_action', collection: client.action_plan_tasks.completed, as: 'action_plan_task'
+  .profile-tab
+    .column
+      - if client.action_plan_tasks.ongoing.any?
+        %table.table
+          %thead
+            %tr
+              %th Agreed Action
+              %th Due Date
+              %th Action for
+              %th
+          %tbody
+            = render partial: 'ongoing_action', collection: client.action_plan_tasks.ongoing, as: 'action_plan_task'
+      - else
+        %p="#{client.name} has no actions yet"
+
+        =button_to "Create first task", new_advisor_client_action_plan_task_path(client), method: :get, class: "button is-primary"
+
+
+      - if client.action_plan_tasks.completed.any?
+        .head.level
+          .level-left
+            %h2 Completed Actions
+            %span
+              =client.action_plan_tasks.completed.count
+        %table.table
+          %thead
+            %tr
+              %th Agreed Action
+              %th Completion Date
+              %th Action for
+              %th
+          %tbody
+            = render partial: 'completed_action', collection: client.action_plan_tasks.completed, as: 'action_plan_task'

--- a/app/views/advisor/action_plan_tasks/index.html.haml
+++ b/app/views/advisor/action_plan_tasks/index.html.haml
@@ -1,4 +1,4 @@
-.column.is-10-widescreen.is-offset-1-widescreen
+.column
   =button_to I18n.t('clients.buttons.new_action_plan_task'), new_advisor_client_action_plan_task_path(client), method: :get, class: "button is-primary is-small"
 
   .head.level

--- a/app/views/advisor/action_plan_tasks/new.html.haml
+++ b/app/views/advisor/action_plan_tasks/new.html.haml
@@ -3,6 +3,6 @@
   = simple_form_for [client, new_action_plan_task], url: advisor_client_action_plan_tasks_path(client_id: client.id) do |form|
     = render partial: 'form_fields', locals: {form: form}
 
-    = link_to I18n.t('clients.buttons.cancel'), advisor_client_action_plan_tasks_path(client_id: client.id), method: :get, class: "button is-primary"
+    = link_to I18n.t('clients.buttons.cancel'), advisor_client_action_plan_tasks_path(client_id: client.id), method: :get, class: "button"
     = form.submit I18n.t('clients.buttons.save'), class: "button is-primary", id: 'save_and_exit'
     = form.submit I18n.t('clients.buttons.create_next_task'), class: "button is-primary", id: 'save_and_next'

--- a/app/views/advisor/action_plan_tasks/new.html.haml
+++ b/app/views/advisor/action_plan_tasks/new.html.haml
@@ -1,4 +1,4 @@
-%section.column.is-10.is-offset-1
+%section.column
   %h2= "Add a task to the action plan"
   = simple_form_for [client, new_action_plan_task], url: advisor_client_action_plan_tasks_path(client_id: client.id) do |form|
     = render partial: 'form_fields', locals: {form: form}

--- a/app/views/advisor/clients/_actions.html.haml
+++ b/app/views/advisor/clients/_actions.html.haml
@@ -10,8 +10,6 @@
   - elsif @client.advisor != current_advisor
     .column
       =button_to I18n.t('clients.buttons.assign_to_me'), advisor_client_assign_path(client_id: @client.id, client: {advisor_id: current_advisor.id }), method: :put, class: "button is-primary is-small"
-  -else
-    .column
-      =@client.decorate_meetings_action
+
 %section
   = link_to I18n.t('clients.buttons.action_plan'), advisor_client_action_plan_tasks_path(client_id: @client.id), class: "button is-primary is-small"

--- a/app/views/advisor/clients/_actions.html.haml
+++ b/app/views/advisor/clients/_actions.html.haml
@@ -10,6 +10,3 @@
   - elsif @client.advisor != current_advisor
     .column
       =button_to I18n.t('clients.buttons.assign_to_me'), advisor_client_assign_path(client_id: @client.id, client: {advisor_id: current_advisor.id }), method: :put, class: "button is-primary is-small"
-
-%section
-  = link_to I18n.t('clients.buttons.action_plan'), advisor_client_action_plan_tasks_path(client_id: @client.id), class: "button is-primary is-small"

--- a/app/views/advisor/clients/_tab_employment.html.haml
+++ b/app/views/advisor/clients/_tab_employment.html.haml
@@ -6,3 +6,18 @@
   =form.input :job_title, as: :string, :label => 'What is your current job title?', :input_html => { :class => 'input' }
   =form.input :working_hours_per_week, as: :integer, :label => 'How many hours per week do you currently work?', :input_html => { :class => 'input' }
   =form.input :below_living_wage, as: :radio_buttons, :label => 'Are the earnings from your job below the living wage?', wrapper_html: { class: "convert_radio" }
+
+#file_uploads
+  -if @client.file_uploads.any?
+    %table.table
+      %thead
+        %tr
+          %th File name
+          %th Uploaded by
+          %th Date Uploaded
+          %th
+      %tbody
+        = render partial: 'shared/file_upload', collection: @client.file_uploads
+  -else
+    %p.bold No CV uploaded yet. Upload a CV even if it's in draft form
+    =@client.new_file_button

--- a/app/views/advisor/clients/edit.html.haml
+++ b/app/views/advisor/clients/edit.html.haml
@@ -51,6 +51,21 @@
 
             = render partial: '/shared/client_profile_overview'
 
+            #file_uploads
+              -if @client.file_uploads.any?
+                %table.table
+                  %thead
+                    %tr
+                      %th File name
+                      %th Uploaded by
+                      %th Date Uploaded
+                      %th
+                  %tbody
+                    = render partial: 'shared/file_upload', collection: @client.file_uploads
+              -else
+                %p.bold No CV uploaded yet. Upload a CV even if it's in draft form
+                =@client.new_file_button
+
           #tabs-2.tab
             = render partial: 'tab_strengths', :locals => {:form => form}
 

--- a/app/views/advisor/clients/edit.html.haml
+++ b/app/views/advisor/clients/edit.html.haml
@@ -1,8 +1,6 @@
-#tabs.container
-  .column.is-10.is-offset-1
-    = simple_form_for [@client.object], url: advisor_client_path(@client.object), method: :put do |form|
-
-
+= simple_form_for [@client.object], url: advisor_client_path(@client.object), method: :put do |form|
+  #tabs.container
+    .column
       .head.level
         .level-left
           %h2=@client.name
@@ -14,74 +12,77 @@
         .level-right
           = form.submit 'Save', :class => 'button is-primary'
 
-      .column.tabs.is-centered
-        %ul
-          %li
-            %a{href: "#tabs-1"}
-              %span Details
-          %li
-            %a{href: "#tabs-2"}
-              %span Strengths
-          %li
-            %a{href: "#tabs-3"}
-              %span Aspirations
-          %li
-            %a{href: "#tabs-4"}
-              %span Support
-          %li
-            %a{href: "#tabs-5"}
-              %span Education
-          %li
-            %a{href: "#tabs-6"}
-              %span Employment
-          %li
-            %a{href: "#tabs-7"}
-              %span Additional Info
-          %li
-            %a{href: "#tabs-8"}
-              %span Notes
+      = render partial: 'shared/upper_tabs', locals: {the_client: @client}
+
+      .profile-tab.top-left-corner
+        .column.tabs.is-centered
+          %ul
+            %li
+              %a{href: "#tabs-1"}
+                %span Details
+            %li
+              %a{href: "#tabs-2"}
+                %span Strengths
+            %li
+              %a{href: "#tabs-3"}
+                %span Aspirations
+            %li
+              %a{href: "#tabs-4"}
+                %span Support
+            %li
+              %a{href: "#tabs-5"}
+                %span Education
+            %li
+              %a{href: "#tabs-6"}
+                %span Employment
+            %li
+              %a{href: "#tabs-7"}
+                %span Additional Info
+            %li
+              %a{href: "#tabs-8"}
+                %span Notes
 
 
-      .column
-        #tabs-1.tab
-          %h3="#{@client.name}'s Details"
+        .column
+          #tabs-1.tab
+            %h3="#{@client.name}'s Details"
 
-          = render 'shared/form_errors', object: form.object
+            = render 'shared/form_errors', object: form.object
 
-          = render partial: '/shared/client_profile_overview'
+            = render partial: '/shared/client_profile_overview'
 
-        #tabs-2.tab
-          = render partial: 'tab_strengths', :locals => {:form => form}
+          #tabs-2.tab
+            = render partial: 'tab_strengths', :locals => {:form => form}
 
-        #tabs-3.tab
-          = render partial: 'tab_aspirations', :locals => {:form => form}
+          #tabs-3.tab
+            = render partial: 'tab_aspirations', :locals => {:form => form}
 
-        #tabs-4.tab
-          = render partial: 'tab_support', :locals => {:form => form}
+          #tabs-4.tab
+            = render partial: 'tab_support', :locals => {:form => form}
 
-        #tabs-5.tab
-          = render partial: 'tab_education', :locals => {:form => form}
+          #tabs-5.tab
+            = render partial: 'tab_education', :locals => {:form => form}
 
-        #tabs-6.tab
-          = render partial: 'tab_employment', :locals => {:form => form}
+          #tabs-6.tab
+            = render partial: 'tab_employment', :locals => {:form => form}
 
-        #tabs-7.tab
-          = render partial: 'tab_additional', :locals => {:form => form}
+          #tabs-7.tab
+            = render partial: 'tab_additional', :locals => {:form => form}
 
-        #tabs-8.tab
-          = render partial: 'tab_notes', :locals => {:form => form}
+          #tabs-8.tab
+            = render partial: 'tab_notes', :locals => {:form => form}
 
-    #file_uploads
-      -if @client.file_uploads.any?
-        %table.table
-          %thead
-            %tr
-              %th File name
-              %th Uploaded by
-              %th Date Uploaded
-              %th
-          %tbody
-            = render partial: 'shared/file_upload', collection: @client.file_uploads
-      -else
-        %p.bold No CV uploaded yet. Upload a CV even if it's in draft form
-        =@client.new_file_button
+        #file_uploads
+          -if @client.file_uploads.any?
+            %table.table
+              %thead
+                %tr
+                  %th File name
+                  %th Uploaded by
+                  %th Date Uploaded
+                  %th
+              %tbody
+                = render partial: 'shared/file_upload', collection: @client.file_uploads
+          -else
+            %p.bold No CV uploaded yet. Upload a CV even if it's in draft form
+            =@client.new_file_button

--- a/app/views/advisor/clients/edit.html.haml
+++ b/app/views/advisor/clients/edit.html.haml
@@ -14,8 +14,8 @@
 
       = render partial: 'shared/upper_tabs', locals: {the_client: @client}
 
-      .profile-tab.top-left-corner
-        .column.tabs.is-centered
+      .profile-tab.top-left-corner.columns
+        #tab-list.column.is-2
           %ul
             %li
               %a{href: "#tabs-1"}
@@ -72,17 +72,3 @@
           #tabs-8.tab
             = render partial: 'tab_notes', :locals => {:form => form}
 
-        #file_uploads
-          -if @client.file_uploads.any?
-            %table.table
-              %thead
-                %tr
-                  %th File name
-                  %th Uploaded by
-                  %th Date Uploaded
-                  %th
-              %tbody
-                = render partial: 'shared/file_upload', collection: @client.file_uploads
-          -else
-            %p.bold No CV uploaded yet. Upload a CV even if it's in draft form
-            =@client.new_file_button

--- a/app/views/advisor/clients/index.html.haml
+++ b/app/views/advisor/clients/index.html.haml
@@ -1,4 +1,4 @@
-#all_clients
+#all_clients.column
   .head.level
     .level-left
       %h2 All Clients

--- a/app/views/advisor/clients/index.html.haml
+++ b/app/views/advisor/clients/index.html.haml
@@ -1,4 +1,4 @@
-#all_clients.column.is-10-widescreen.is-offset-1-widescreen
+#all_clients
   .head.level
     .level-left
       %h2 All Clients

--- a/app/views/advisor/file_uploads/new.html.haml
+++ b/app/views/advisor/file_uploads/new.html.haml
@@ -1,4 +1,4 @@
-%section.new_file_upload.column.is-10.is-offset-1
+%section.new_file_upload.column
   %h2= "Upload a file"
   = simple_form_for [client, new_file_upload], url: advisor_client_file_uploads_path(client) do |form|
     = render 'shared/form_errors', object: form.object

--- a/app/views/advisor/meetings/edit.html.haml
+++ b/app/views/advisor/meetings/edit.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h3.subtitle Meeting arrangements
   %hr
   %p Please record the date your meeting

--- a/app/views/advisor/meetings/index.html.haml
+++ b/app/views/advisor/meetings/index.html.haml
@@ -1,19 +1,27 @@
-.column.is-10-widescreen.is-offset-1-widescreen
-  =button_to I18n.t('clients.buttons.arrange_meeting'), new_advisor_client_meeting_path(client), method: :get, class: "button is-primary is-small"
-
+.column
   .head.level
     .level-left
-      %h2 Meetings
-      %span
-        =client.meetings_count
+      %h2="#{client.first_name}'s Meetings"
+      %span.client_total=client.meetings_count
 
-  %section
-    %table.table
-      %thead
-        %tr
-          %th Scheduled For Date
-          %th Agenda
-          %th Advisor
-          %th
-      %tbody
-        = render partial: 'meeting', collection: client.meetings
+    .level-right
+      =button_to I18n.t('clients.buttons.arrange_meeting'), new_advisor_client_meeting_path(client), method: :get, class: "button is-primary"
+
+  = render partial: 'shared/upper_tabs', locals: {the_client: client}
+
+  .profile-tab
+    .column
+      -if client.meetings.any?
+        %table.table
+          %thead
+            %tr
+              %th Scheduled For Date
+              %th Agenda
+              %th Advisor
+              %th
+          %tbody
+            = render partial: 'meeting', collection: client.meetings
+      - else
+        %p No current meetings
+
+        =button_to I18n.t('clients.buttons.arrange_meeting'), new_advisor_client_meeting_path(client), method: :get, class: "button is-primary"

--- a/app/views/advisor/meetings/new.html.haml
+++ b/app/views/advisor/meetings/new.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h3.subtitle Meeting arrangements
   %hr
   %p Please record the date your meeting

--- a/app/views/advisor/my_clients/index.html.haml
+++ b/app/views/advisor/my_clients/index.html.haml
@@ -1,4 +1,4 @@
-#your_clients.column.is-10-widescreen.is-offset-1-widescreen
+#your_clients.column
 
   .head.columns.level
     .level-left.column
@@ -11,7 +11,7 @@
   -if @clients_needing_appointment.any?
     %section#clients_needing_appointment.hero.is-fullwidth.section
       .container.content.columns
-        .column.is-10.is-offset-1
+        .column
           %h4.bold
             ="You have #{pluralize(@clients_needing_appointment.count, 'client')} that still require initial contact"
 

--- a/app/views/client/additional_information/edit.html.haml
+++ b/app/views/client/additional_information/edit.html.haml
@@ -1,7 +1,7 @@
 .column.is-12.has-text-centered
   = render partial: 'shared/profile_steps'
 
-.column.is-10.is-offset-1
+.column
   %h2.subtitle=I18n.t('clients.steps.additional_information.long')
 
   = simple_form_for [current_client], url: :client_additional_information do |form|

--- a/app/views/client/education/edit.html.haml
+++ b/app/views/client/education/edit.html.haml
@@ -1,6 +1,6 @@
 .column.is-12.has-text-centered
   = render partial: 'shared/profile_steps'
-.column.is-10.is-offset-1
+.column
   %h2.subtitle=I18n.t('clients.steps.education.long')
 
   = simple_form_for [current_client], url: :client_education do |form|

--- a/app/views/client/employment_status/edit.html.haml
+++ b/app/views/client/employment_status/edit.html.haml
@@ -1,7 +1,7 @@
 .column.is-12.has-text-centered
   = render partial: 'shared/profile_steps'
 
-.column.is-10.is-offset-1
+.column
   %h2.subtitle=I18n.t('clients.steps.employment.long')
 
   = simple_form_for [current_client], url: :client_employment_status do |form|

--- a/app/views/client/objectives/edit.html.haml
+++ b/app/views/client/objectives/edit.html.haml
@@ -1,6 +1,6 @@
 .column.is-12.has-text-centered
   = render partial: 'shared/profile_steps'
-.column.is-10.is-offset-1
+.column
   %h2.subtitle=I18n.t('clients.steps.objectives.long')
 
   = simple_form_for [current_client], url: :client_objectives do |form|

--- a/app/views/client/passwords/edit.html.haml
+++ b/app/views/client/passwords/edit.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Create your password
 
   = form_for(@user_login, url: user_login_password_path, html: { method: :put }) do |f|

--- a/app/views/client/personal_traits/edit.html.haml
+++ b/app/views/client/personal_traits/edit.html.haml
@@ -1,6 +1,6 @@
 .column.is-12.has-text-centered
   = render partial: 'shared/profile_steps'
-.column.is-10.is-offset-1
+.column
   %h2.subtitle=I18n.t('clients.steps.about_you.long')
 
   = simple_form_for [current_client], url: :client_personal_traits do |form|

--- a/app/views/client/profiles/show.html.haml
+++ b/app/views/client/profiles/show.html.haml
@@ -1,2 +1,2 @@
-.column.is-10.is-offset-1
+.column
   = render partial: '/shared/client_profile_overview'

--- a/app/views/clients/new.html.haml
+++ b/app/views/clients/new.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   = simple_form_for [@client] do |form|
 
     %fieldset

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Resend confirmation instructions
 
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Change your password
 
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Forgot your password?
 
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Sign up
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     = devise_error_messages!

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Log in
   = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     .field

--- a/app/views/eligibility/outside_hackney.html.haml
+++ b/app/views/eligibility/outside_hackney.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Do you live within Hackney?
 
   %p Sorry, this service is only for Hackney residents.

--- a/app/views/hubs/index.html.haml
+++ b/app/views/hubs/index.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h3 Hackney advisors in your area
   %br
   #hubs= render partial: 'hub', collection: Hub.all

--- a/app/views/just_registered/show.html.haml
+++ b/app/views/just_registered/show.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Thank you for registering with Hackney Works!
 
   %p To confirm your identity you will soon receive an email with a link to create a password for your account. You don’t have to do this but it helps our advisors to prepare for your meeting, and it means you will be able to access and edit your account details in the future.

--- a/app/views/service_manager/clients/index.html.haml
+++ b/app/views/service_manager/clients/index.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
 
   %h4 All clients
   %ul

--- a/app/views/service_manager/clients/show.html.haml
+++ b/app/views/service_manager/clients/show.html.haml
@@ -1,2 +1,2 @@
-.column.is-10.is-offset-1
+.column
   = render partial: '/shared/client_profile_overview'

--- a/app/views/shared/_upper_tabs.html.haml
+++ b/app/views/shared/_upper_tabs.html.haml
@@ -1,4 +1,4 @@
-#upper-tabs.level
+#upper-tabs.columns.level
   = link_to edit_advisor_client_path(the_client), class: "single-tab #{cp(edit_advisor_client_path(the_client))}" do
     %span="#{the_client.first_name}'s Profile"
   = link_to advisor_client_meetings_path(the_client), class: "single-tab #{cp(advisor_client_meetings_path(the_client))}" do

--- a/app/views/shared/_upper_tabs.html.haml
+++ b/app/views/shared/_upper_tabs.html.haml
@@ -1,0 +1,9 @@
+#upper-tabs.level
+  = link_to edit_advisor_client_path(the_client), class: "single-tab #{cp(edit_advisor_client_path(the_client))}" do
+    %span="#{the_client.first_name}'s Profile"
+  = link_to advisor_client_meetings_path(the_client), class: "single-tab #{cp(advisor_client_meetings_path(the_client))}" do
+    %span="#{the_client.first_name}'s Meetings"
+  = link_to advisor_client_action_plan_tasks_path(client_id: the_client.id), class: "single-tab #{cp(advisor_client_action_plan_tasks_path(client_id: the_client.id))}" do
+    %span="#{the_client.first_name}'s Action Plan"
+  %a.single-tab{href: "#"}
+    %span="#{the_client.first_name}'s Timeline"

--- a/app/views/welcome/show.html.haml
+++ b/app/views/welcome/show.html.haml
@@ -1,4 +1,4 @@
-.column.is-10.is-offset-1
+.column
   %h2.subtitle Welcome to Ways Into Work
 
   %p We support Hackney residents who are looking for jobs, apprenticeships, training or volunteering opportunities.


### PR DESCRIPTION
update to the profile page - there are a few more tweaks needing to be made, but its in a stable enough position. 

stuff left to do in the client profile page includes:
* styling and better structure to the pages for new/edit meetings and action plans - in particular around the buttons at the bottom
* we will probably want to re style the table lists being used for action plan and for meetings index as a: its a bit too similar to the client list view and I think each one will need its own style, and b: its now on a white background so the list having white background doesnt help.
* styling the details screen (which is currently a data dump) Jan has some sketches for this screen for laying out the info in a slightly nicer way.
* possibly adding call to actions for meetings/action plan for creating new ones at the bottom of the screen too (maybe only if the list is long)
* add in some form of breadcrumb or back link to the sub pages like schedule meeting and create action

there is also a slightly major update to the structure of most pages - previously almost all pages in the advisor view were restricted to 10 columns due - I originally did this because I was viewing it on such a large screen size - but I recently noticed even at fairly normal screen sizes like below 1440px there was a bug in this 10 column structure. I have changed some of the break points and removed the 10 columns, its working better now.