### PR TITLE
Search misspelled names

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -62,7 +62,11 @@ class Client < ApplicationRecord
     where('date_of_birth  > ?', Time.zone.today - 25.years) if under_25s
   }
 
-  pg_search_scope :search_query, against: %i[first_name last_name]
+  pg_search_scope :search_query, against: %i[first_name last_name], using: {
+    trigram: {
+      threshold: 0.1
+    }
+  }
 
   def next_meeting_date
     upcoming_meetings.first.start_datetime.to_date.to_s(:long) if upcoming_meetings.any?

--- a/db/fixtures/production/01_advisors.rb
+++ b/db/fixtures/production/01_advisors.rb
@@ -51,8 +51,8 @@ advisors = [
     name: 'Nasima Begum',
     phone: '020 8356 7634',
     hub_id: 3
-  },{
-    email: "olayinka.aremu@hackney.gov.uk",
+  }, {
+    email: 'olayinka.aremu@hackney.gov.uk',
     name: 'Olayinka Aremu',
     phone: '020 8356 3320',
     hub_id: 3

--- a/db/migrate/20171204162002_add_trigram_extension.rb
+++ b/db/migrate/20171204162002_add_trigram_extension.rb
@@ -1,0 +1,5 @@
+class AddTrigramExtension < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'pg_trgm' 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_170_815_143_654) do
+ActiveRecord::Schema.define(version: 20_171_204_162_002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
+  enable_extension 'pg_trgm'
 
   create_table 'action_plan_tasks', force: :cascade do |t|
     t.string 'title'

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Client, type: :model do
       expect(Client.search_query('Catherine')).to eq([client1])
       expect(Client.search_query('Robynson')).to eq([client2])
       expect(Client.search_query('Mohammed')).to eq([client3])
+      expect(Client.search_query('muhammad')).to eq([client3])
     end
     
   end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Client, type: :model do
+  
+  context 'search by name' do
+    
+    let(:client1) { Fabricate.create(:client, first_name: 'Katherine') }
+    let(:client2) { Fabricate.create(:client, last_name: 'Robynson') }
+    let(:client3) { Fabricate.create(:client, first_name: 'Muhammad') }
+
+    it 'is not fussy about spellings' do
+      expect(Client.search_query('Catherine')).to eq([client1])
+      expect(Client.search_query('Robynson')).to eq([client2])
+      expect(Client.search_query('Mohammed')).to eq([client3])
+    end
+    
+  end
+  
+
+  
+end


### PR DESCRIPTION
Adding the postgres Trigram extension to make it easier for advisors to search names with different spellings