### PR TITLE
Clean tab

### DIFF
--- a/app/assets/stylesheets/advisors.sass
+++ b/app/assets/stylesheets/advisors.sass
@@ -151,23 +151,24 @@ a[data-icon='envelope']
     text-transform: uppercase
     font-weight: $weight-medium
   .single-tab
-    padding: 15px 45px 18px 45px
+    padding: 15px 30px
     opacity: 0.5
     &:hover
       opacity: 1
     &.current
+      line-height: 1.5
       opacity: 1
       background-color: #fff
       border-top-left-radius: 5px
       border-top-right-radius: 5px
       border: 1px rgba(29, 29, 27, 0.15) solid
       border-bottom: none
+      display: inline-block
       &:hover
         cursor: default
     &:first-child.current
       margin-left: -0.75em
     &:last-child.current
-      margin-right: -1px
 
 .profile-tab
   border: 1px rgba(29, 29, 27, 0.15) solid

--- a/app/assets/stylesheets/components/level.sass
+++ b/app/assets/stylesheets/components/level.sass
@@ -43,9 +43,10 @@
     display: flex
 
 .level
+  &.head
+    justify-content: space-between
   +block
   align-items: center
-  justify-content: space-between
   code
     border-radius: $radius
   img

--- a/app/views/advisor/clients/_latest_file_upload.html.haml
+++ b/app/views/advisor/clients/_latest_file_upload.html.haml
@@ -1,0 +1,9 @@
+-if client.file_uploads.any?
+  %p Latest upload:
+  %p=link_to client.file_uploads.first.attachment_file_name, client.file_uploads.first.attachment.try(:url), title: client.file_uploads.first.attachment_file_name, target: :blank
+  %p="Uploaded by: #{client.file_uploads.first.uploaded_by} on #{client.file_uploads.first.created_at.to_date.to_s(:short)}"
+  =client.new_file_button(I18n.t('clients.buttons.manage_uploads'))
+-else
+  %p.bold
+    = t('clients.onboarding.employment.upload')
+  =client.new_file_button(I18n.t('clients.buttons.upload_cv'))

--- a/app/views/advisor/contact_notes/index.html.haml
+++ b/app/views/advisor/contact_notes/index.html.haml
@@ -23,6 +23,4 @@
             = render partial: 'contact_note', collection: client.contact_notes
 
     .box
-      %h2 Archive client and opt-out
-      %p Use if: your client is no longer interested and doesn't want to be contacted
       =button_to I18n.t('clients.buttons.archive_client'), advisor_client_path(client), method: :delete, class: "button is-danger is-small"

--- a/app/views/advisor/contact_notes/new.html.haml
+++ b/app/views/advisor/contact_notes/new.html.haml
@@ -8,19 +8,15 @@
   %hr
 
   .box
-    %h2 Contact details
-    %p=client.decorate_preferred_contact
-  .box
-    %h2 Scheduled new meeting
-    %p Use if: you successfully booked a meeting with the client
+    %h2 Schedule a new meeting
+    %p
+    %label.label
+      = "#{client.first_name}'s contact details"
+    =client.decorate_preferred_contact
     =button_to I18n.t('clients.buttons.arrange_meeting'), new_advisor_client_meeting_path(client), method: :get, class: "button is-primary is-small"
   .box
-    %h2 Contacted client
-
-    %p Use if
-    %ul
-      %li You contacted the client, but did not book a meeting
-      %li You tried to contact the client and was unsuccessful
+    %h2 
+      = "#{client.first_name}'s contact notes"
 
     = simple_form_for [client, contact_note], url: advisor_client_contact_notes_path(client_id: client.id) do |form|
 
@@ -31,7 +27,7 @@
           =form.input :contact_method, as: :radio_buttons, collection: ContactMethodOption.all, :label => 'How did you communicate with them?', include_hidden: false
 
         .field
-          =form.input :content, as: :text, :input_html => { :class => "textarea" }
+          =form.input :content, as: :text, label: 'Notes', :input_html => { :class => "textarea" }
 
         =form.input :client_id, as: :hidden
         =form.input :advisor_id, as: :hidden
@@ -40,6 +36,4 @@
         = form.submit I18n.t('clients.buttons.save'), :class => 'button is-primary'
 
   .box
-    %h2 Archive client and opt-out
-    %p Use if: your client is no longer interested and doesn't want to be contacted
     =button_to I18n.t('clients.buttons.archive_client'), advisor_client_path(client), method: :delete, class: "button is-danger is-small"

--- a/app/views/client/employment_status/edit.html.haml
+++ b/app/views/client/employment_status/edit.html.haml
@@ -13,7 +13,7 @@
     .is-hidden.on-true
       =form.input :job_title, as: :string, :label => 'What is your current job title?', :input_html => { :class => 'input' }
 
-    = render partial: '/shared/latest_file_upload', as: :client, object: form.object
+    = render partial: '/advisor/clients/latest_file_upload', as: :client, object: form.object
     .actions
       = form.submit 'Complete Profile', :class => 'button is-primary is-pulled-right'
       = form.submit I18n.t('clients.buttons.onboarding_skip'), :class => 'button'

--- a/app/views/shared/_upper_tabs.html.haml
+++ b/app/views/shared/_upper_tabs.html.haml
@@ -1,9 +1,9 @@
 #upper-tabs.columns.level
   = link_to edit_advisor_client_path(the_client), class: "single-tab #{cp(edit_advisor_client_path(the_client))}" do
-    %span="#{the_client.first_name}'s Profile"
+    %span="Profile"
   = link_to advisor_client_meetings_path(the_client), class: "single-tab #{cp(advisor_client_meetings_path(the_client))}" do
-    %span="#{the_client.first_name}'s Meetings"
+    %span="Meetings"
   = link_to advisor_client_action_plan_tasks_path(client_id: the_client.id), class: "single-tab #{cp(advisor_client_action_plan_tasks_path(client_id: the_client.id))}" do
-    %span="#{the_client.first_name}'s Action Plan"
+    %span="Action Plan"
   = link_to advisor_client_contact_notes_path(client_id: the_client.id), class: "single-tab #{cp(advisor_client_contact_notes_path(client_id: the_client.id))}" do
-    %span="#{the_client.first_name}'s Contact Timeline"
+    %span="Contact"

--- a/config/locales/clients.en.yml
+++ b/config/locales/clients.en.yml
@@ -13,6 +13,9 @@ en:
     mail:
       subject:
         welcome: "Welcome to Hackney Works"
+    onboarding:
+      employment:
+        upload: "Upload a CV. Don’t worry if you don’t have one!"
     steps:
       about_you:
         long: "Tell us a little about yourself"
@@ -21,7 +24,7 @@ en:
         long: "Tell us about your employment status"
         short: "Employment"
         employed: "Are you currently employed?"
-        upload: "Nothing uploaded. Upload a CV, cover letter or draft documents"
+        upload: "Upload a CV, cover letter or draft documents"
       objectives:
         long: "What can we help you with?"
         short: "Goals"
@@ -32,11 +35,11 @@ en:
         long: "For monitoring purposes please provide us with some details about you"
         short: "Details"
     buttons:
-      archive_client: 'Archive client record'
+      archive_client: 'Archive client record and opt-out'
       upload_cv: 'Upload CV'
       upload: 'Upload'
       manage_cvs: 'Manage CVs'
-      manage_uploads: 'Manage files'
+      manage_uploads: 'Manage uploads'
       delete: 'Delete'
       make_contact: "Contact"
       arrange_meeting: "Schedule meeting"

--- a/features/step_definitions/action_plan_steps.rb
+++ b/features/step_definitions/action_plan_steps.rb
@@ -1,6 +1,6 @@
 Given(/^I assign a new action plan task to them$/) do
   click_on @client.name
-  click_on "#{@client.first_name}'s Action Plan"
+  click_on 'Action Plan'
   click_on I18n.t('clients.buttons.new_action_plan_task'), match: :first
   @task_title = 'Do Something'
   @due_date = DateTime.now.utc + 7.days


### PR DESCRIPTION
Fixed the tab/overlapping text in ipad view.
Updated to correct copy and flow for CV uploading, separating onboarding and advisor upload.