### PR TITLE
Trying to order clients

### DIFF
--- a/app/controllers/advisor/my_clients_controller.rb
+++ b/app/controllers/advisor/my_clients_controller.rb
@@ -1,6 +1,6 @@
 class Advisor::MyClientsController < Advisor::BaseController
   def index
-    @clients_requiring_contact = current_advisor.clients.needing_contact.to_a
+    @clients_requiring_contact = current_advisor.clients.needing_contact.sort_by {|obj| obj.created_at }.reverse
     init_filtered_clients
     respond_to do |format|
       format.html


### PR DESCRIPTION
The last edited client now shows at the top of the clients awaiting contact, but this doesn't work for those that are shifted below within 'hide more clients'.

It's probably all wrong but wanted to share my attempt.