### PR TITLE
Create initial meeting if an advisor creates a client

### DIFF
--- a/app/controllers/advisor/clients_controller.rb
+++ b/app/controllers/advisor/clients_controller.rb
@@ -8,7 +8,7 @@ class Advisor::ClientsController < Advisor::BaseController # rubocop:disable Cla
   end
 
   def create
-    if client.save
+    if client.save && client.generate_initial_meeting
       flash[:success] = "#{client.name} saved."
       redirect_to edit_advisor_client_path(client)
     else

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -185,4 +185,13 @@ class Client < ApplicationRecord # rubocop:disable ClassLength
     AdvisorMailer.notify_client_signed_up(self).deliver_now
   end
   
+  def generate_initial_meeting
+    meetings.create(
+      start_datetime: Time.zone.now,
+      advisor: advisor,
+      client_attended: true,
+      agenda: 'initial_assessment'
+    )
+  end
+  
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,8 +13,8 @@
 ActiveRecord::Schema.define(version: 20180105110044) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_trgm"
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "action_plan_tasks", force: :cascade do |t|
     t.string "title"

--- a/features/advisors/creates_client.feature
+++ b/features/advisors/creates_client.feature
@@ -11,3 +11,4 @@ Feature: Advisor creates a new client
   Scenario: Create a new client
     Given I register a client as "client@example.com"
     Then the client should be assigned to me
+    And that client should have an initial meeting created

--- a/features/step_definitions/client_steps.rb
+++ b/features/step_definitions/client_steps.rb
@@ -34,6 +34,13 @@ Then(/^the client should be assigned to me$/) do
   expect(client.advisor).to eq(@i)
 end
 
+Then(/^that client should have an initial meeting created$/) do
+  client = Client.last
+  expect(client.meetings.count).to eq(1)
+  meeting = client.meetings.first
+  expect(meeting.agenda).to eq('initial_assessment')
+end
+
 Given(/^I have been referred$/) do
   @referrer = Fabricate.create(:referrer)
   @i.referrer = @referrer


### PR DESCRIPTION
This means that walk-in clients are not shown as needing initial contact. It also means that advisors can make any notes about that initial meeting when the client registered.