### PR TITLE
Add engagement role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,22 +6,15 @@ class ApplicationController < ActionController::Base
   layout 'default'
 
   def after_sign_in_path_for(resource_or_scope)
-    user_root(resource_or_scope.user_type)
+    user_root(resource_or_scope)
   end
 
   def after_sign_out_path_for(_resource_or_scope)
     :hackney_works
   end
 
-  def user_root(user_type = current_user_login.try(:user_type))
-    case user_type
-    when 'Advisor'
-      :advisor_my_clients
-    when 'Client'
-      :client_dashboard
-    else
-      '/'
-    end
+  def user_root(login = current_user_login)
+    login&.root_page || '/'
   end
 
   def not_authorised

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -31,4 +31,16 @@ class Advisor < ApplicationRecord
       by_hub_id(hub_id).order('LOWER(name)')
     end.map { |e| [e.name, e.id, { 'data-hub-id' => e&.hub&.id }] }
   end
+  
+  def hackney_works_team?
+    advisor? || team_leader?
+  end
+  
+  def root_page
+    if hackney_works_team?
+      :advisor_my_clients
+    else
+      :advisor_clients
+    end
+  end
 end

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -21,7 +21,7 @@ class Advisor < ApplicationRecord
   end
   
   def default_hub_id
-    options['show_all_hubs'] == true ? nil : hub_id
+    admin? || employer_engagement? ? nil : hub_id
   end
 
   def self.options_for_select(hub_id)

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -14,7 +14,7 @@ class Advisor < ApplicationRecord
 
   scope :by_hub_id, ->(hub_id) { where(hub_id: hub_id) }
 
-  scope :team_leader, ->(hub) { where(hub: hub, team_leader: true) }
+  scope :team_leader, ->(hub) { where(hub: hub, role: :team_leader) }
 
   def devise_mailer
     Devise::Mailer

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -9,6 +9,8 @@ class Advisor < ApplicationRecord
   belongs_to :hub
 
   has_many :clients
+  
+  enum role: %i[advisor team_leader]
 
   scope :by_hub_id, ->(hub_id) { where(hub_id: hub_id) }
 

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -10,7 +10,7 @@ class Advisor < ApplicationRecord
 
   has_many :clients
   
-  enum role: %i[advisor team_leader]
+  enum role: %i[advisor team_leader admin employer_engagement]
 
   scope :by_hub_id, ->(hub_id) { where(hub_id: hub_id) }
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -189,6 +189,10 @@ class Client < ApplicationRecord # rubocop:disable ClassLength
     @age ||= (DateTime.current.mjd - date_of_birth.to_date.mjd) / 365 if date_of_birth
   end
   
+  def root_page
+    :client_dashboard
+  end
+  
   def csv_row # rubocop:disable Rails/MethodLength, Metrics/AbcSize
     [
       created_at.to_date,

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -217,7 +217,7 @@ class Client < ApplicationRecord # rubocop:disable ClassLength
 
   def assign_team_leader(ward_mapit_code)
     self.advisor = Advisor.team_leader(Hub.covering_ward(ward_mapit_code)).first ||
-                   Advisor.find_by(team_leader: true)
+                   Advisor.find_by(role: :team_leader)
   end
   
   def assign_advisor(advisor_id, current_advisor)

--- a/app/models/hub.rb
+++ b/app/models/hub.rb
@@ -20,6 +20,6 @@ class Hub < ApplicationRecord
   end
 
   def team_leader
-    advisors.find_by(team_leader: true)
+    advisors.find_by(role: :team_leader)
   end
 end

--- a/app/models/user_login.rb
+++ b/app/models/user_login.rb
@@ -6,7 +6,7 @@ class UserLogin < ApplicationRecord
 
   belongs_to :user, polymorphic: true
 
-  delegate :name, :devise_mailer, to: :user
+  delegate :name, :devise_mailer, :root_page, to: :user
 
   def generate_default_password
     self.password = Devise.friendly_token.first(20)

--- a/app/views/advisor/clients/_actions.html.haml
+++ b/app/views/advisor/clients/_actions.html.haml
@@ -1,7 +1,7 @@
 .columns
   = simple_form_for client.object, url: advisor_client_path(client_id: client.id) do |form|
     .column
-      - if current_advisor.team_leader
+      - if current_advisor.team_leader?
         = render 'shared/form_errors', object: form.object
         = form.input :advisor_id, as: :select, collection: Advisor.all, include_blank: false
         = form.submit I18n.t('clients.buttons.assign_advisor'), class: "step button is-primary"

--- a/app/views/advisor/clients/index.html.haml
+++ b/app/views/advisor/clients/index.html.haml
@@ -63,4 +63,4 @@
 
   - else
     %h4=I18n.t('advisors.headers.no_clients_yet')
-    =link_to I18n.t('buttons.my_clients'), advisor_my_clients_path, class: 'button is-primary'
+    =link_to I18n.t('buttons.my_clients'), advisor_my_clients_path, class: 'button is-primary' if current_advisor.hackney_works_team?

--- a/app/views/layouts/_site_header_advisor.html.haml
+++ b/app/views/layouts/_site_header_advisor.html.haml
@@ -5,7 +5,7 @@
   %span
   %span
 .nav-right.nav-menu
-  = link_to "My Clients", user_root, class: "nav-item is-tab #{cp(user_root)}"
+  = link_to "My Clients", user_root, class: "nav-item is-tab #{cp(user_root)}" if !(current_advisor.admin? || current_advisor.employer_engagement?)
   = link_to "All Clients", :advisor_clients, class: "nav-item is-tab #{cp(:advisor_clients)}"
-  = link_to "Dashboard", :advisor_dashboard_index, class: "nav-item is-tab #{cp(:advisor_dashboard_index)}"
+  = link_to "Dashboard", :advisor_dashboard_index, class: "nav-item is-tab #{cp(:advisor_dashboard_index)}" if !current_advisor.employer_engagement?
   = button_to "Log Out", destroy_user_login_session_path, class: "nav-item is-tab", :method => :delete

--- a/app/views/layouts/_site_header_advisor.html.haml
+++ b/app/views/layouts/_site_header_advisor.html.haml
@@ -5,7 +5,7 @@
   %span
   %span
 .nav-right.nav-menu
-  = link_to "My Clients", user_root, class: "nav-item is-tab #{cp(user_root)}" if !(current_advisor.admin? || current_advisor.employer_engagement?)
+  = link_to "My Clients", user_root, class: "nav-item is-tab #{cp(user_root)}" if current_advisor.hackney_works_team?
   = link_to "All Clients", :advisor_clients, class: "nav-item is-tab #{cp(:advisor_clients)}"
   = link_to "Dashboard", :advisor_dashboard_index, class: "nav-item is-tab #{cp(:advisor_dashboard_index)}" if !current_advisor.employer_engagement?
   = button_to "Log Out", destroy_user_login_session_path, class: "nav-item is-tab", :method => :delete

--- a/db/fixtures/default/01_advisors.rb
+++ b/db/fixtures/default/01_advisors.rb
@@ -6,7 +6,7 @@ advisors = [
   }, {
     email: 'kiran+tl@wearefuturegov.com',
     name: 'Kiran Team Leader',
-    team_leader: true,
+    role: :team_leader,
     hub_id: 1
   }, {
     email: 'chris@wearefuturegov.com',
@@ -15,7 +15,7 @@ advisors = [
   }, {
     email: 'chris+tl@wearefuturegov.com',
     name: 'Chris Team Leader',
-    team_leader: true,
+    role: :team_leader,
     hub_id: 2
   }, {
     email: 'benunsworth@wearefuturegov.com',
@@ -36,7 +36,7 @@ advisors = [
   }, {
     email: 'jan+tl@wearefuturegov.com',
     name: 'Jan Team Leader',
-    team_leader: true,
+    role: :team_leader,
     hub_id: 3
   }, {
     email: 'jrae@wearefuturegov.com',

--- a/db/fixtures/production/01_advisors.rb
+++ b/db/fixtures/production/01_advisors.rb
@@ -12,7 +12,7 @@ advisors = [
   }, {
     email: 'mohammed.jama@hackney.gov.uk',
     name: 'Mohammed Jama',
-    team_leader: true,
+    role: :team_leader,
     phone: '020 8356 6471',
     hub_id: 1
   }, {
@@ -33,7 +33,7 @@ advisors = [
   }, {
     email: 'caroline.modest@hackney.gov.uk',
     name: 'Caroline Modest',
-    team_leader: true,
+    role: :team_leader,
     phone: '020 8356 8189',
     hub_id: 2
   }, {
@@ -64,7 +64,7 @@ advisors = [
   }, {
     email: 'dujon.harvey@hackney.gov.uk',
     name: 'Dujon Harvey',
-    team_leader: true,
+    role: :team_leader,
     phone: '020 8356 7923',
     hub_id: 3
   }, {
@@ -80,7 +80,7 @@ advisors = [
   }, {
     email: 'anna-renee.paisley@hackney.gov.uk',
     name: 'Anna-Renee Paisley',
-    team_leader: true,
+    role: :team_leader,
     phone: '020 8356 1678',
     hub_id: 4
   }

--- a/db/migrate/20180119161524_add_role_to_advisors.rb
+++ b/db/migrate/20180119161524_add_role_to_advisors.rb
@@ -1,0 +1,7 @@
+class AddRoleToAdvisors < ActiveRecord::Migration[5.1]
+  def change
+    add_column :advisors, :role, :integer, default: 0
+    Advisor.where(team_leader: true).each { |a| a.update_column(:role, 1) } # rubocop:disable Rails/SkipsModelValidations
+    remove_column :advisors, :team_leader, :boolean
+  end
+end

--- a/db/migrate/20180119164328_remove_options_from_advisor.rb
+++ b/db/migrate/20180119164328_remove_options_from_advisor.rb
@@ -1,0 +1,5 @@
+class RemoveOptionsFromAdvisor < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :advisors, :options, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180119161524) do
+ActiveRecord::Schema.define(version: 20180119164328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 20180119161524) do
     t.string "name"
     t.bigint "hub_id"
     t.string "phone"
-    t.json "options", default: {}
     t.integer "role", default: 0
     t.index ["hub_id"], name: "index_advisors_on_hub_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180119122521) do
+ActiveRecord::Schema.define(version: 20180119161524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,9 +43,9 @@ ActiveRecord::Schema.define(version: 20180119122521) do
   create_table "advisors", force: :cascade do |t|
     t.string "name"
     t.bigint "hub_id"
-    t.boolean "team_leader", default: false
     t.string "phone"
     t.json "options", default: {}
+    t.integer "role", default: 0
     t.index ["hub_id"], name: "index_advisors_on_hub_id"
   end
 

--- a/features/advisors/default_hubs.feature
+++ b/features/advisors/default_hubs.feature
@@ -10,8 +10,14 @@ Feature: Default hubs on advisor page
     Then my hub should be selected by default
     And I should only see clients from my hub
     
-  Scenario: Advisor with flag set sees all clients
-    Given I have the show_all_hubs option set
+  Scenario: Admin sees all clients
+    Given I am an admin
+    And I am on the advisor clients page
+    Then the any hub option should be selected by default
+    And I should see all clients
+
+  Scenario: Employer Engagement team member sees all clients
+    Given I am in the employer engagement team
     And I am on the advisor clients page
     Then the any hub option should be selected by default
     And I should see all clients

--- a/features/advisors/roles.feature
+++ b/features/advisors/roles.feature
@@ -1,0 +1,22 @@
+Feature: Advisor sign in roles
+
+  Background:
+    Given I am an advisor
+
+  Scenario: Default role
+    When I sign in
+    Then I should be on the my clients page
+    And I should see a link to the my clients page
+    And I should see a link to the dashboard page
+  
+  Scenario: Admin role
+    Given I am an admin
+    When I sign in
+    And I should see a link to the dashboard page
+    And I should not see a link to the my clients page
+  
+  Scenario: Employer Engagement role
+    Given I am an in the employer engagement team
+    When I sign in
+    And I should not see a link to the dashboard page
+    And I should not see a link to the my clients page

--- a/features/advisors/roles.feature
+++ b/features/advisors/roles.feature
@@ -12,11 +12,13 @@ Feature: Advisor sign in roles
   Scenario: Admin role
     Given I am an admin
     When I sign in
+    Then I should be on the advisor clients page
     And I should see a link to the dashboard page
     And I should not see a link to the my clients page
   
   Scenario: Employer Engagement role
     Given I am an in the employer engagement team
     When I sign in
+    Then I should be on the advisor clients page
     And I should not see a link to the dashboard page
     And I should not see a link to the my clients page

--- a/features/step_definitions/advisor_steps.rb
+++ b/features/step_definitions/advisor_steps.rb
@@ -107,8 +107,13 @@ Then(/^I should only see clients from my hub$/) do
   end
 end
 
-Given(/^I have the show_all_hubs option set$/) do
-  @i.options['show_all_hubs'] = true
+Given(/^I am an admin$/) do
+  @i.role = :admin
+  @i.save
+end
+
+Given(/^I am in the employer engagement team$/) do
+  @i.role = :employer_engagement
   @i.save
 end
 

--- a/features/step_definitions/advisor_steps.rb
+++ b/features/step_definitions/advisor_steps.rb
@@ -112,6 +112,11 @@ Given(/^I am an admin$/) do
   @i.save
 end
 
+Given(/^I am an in the employer engagement team$/) do
+  @i.role = :employer_engagement
+  @i.save
+end
+
 Given(/^I am in the employer engagement team$/) do
   @i.role = :employer_engagement
   @i.save

--- a/features/step_definitions/advisor_steps.rb
+++ b/features/step_definitions/advisor_steps.rb
@@ -27,7 +27,7 @@ Given(/^there is an advisor$/) do
 end
 
 Given(/^there is a team leader for homerton$/) do
-  @team_leader = Fabricate(:advisor, team_leader: true, hub: @hub)
+  @team_leader = Fabricate(:advisor, role: :team_leader, hub: @hub)
 end
 
 Then(/^I should be auto assigned to homerton$/) do

--- a/features/step_definitions/path_steps.rb
+++ b/features/step_definitions/path_steps.rb
@@ -28,3 +28,13 @@ Then /^(?:|I )should be on (.+)$/ do |page_name|
   # current_path += "?#{uri.query}" if uri.query
   expect(current_path).to eq path_to(page_name)
 end
+
+Then(/^(?:|I )should see a link to (.+)$/) do |page_name|
+  matcher = all(:css, "a[href='#{path_to(page_name)}']")
+  expect(matcher.count).to be > 0
+end
+
+Then(/^(?:|I )should not see a link to (.+)$/) do |page_name|  
+  matcher = all(:css, "a[href='#{path_to(page_name)}']")
+  expect(matcher.count).to eq 0
+end

--- a/features/step_definitions/path_steps.rb
+++ b/features/step_definitions/path_steps.rb
@@ -31,10 +31,10 @@ end
 
 Then(/^(?:|I )should see a link to (.+)$/) do |page_name|
   matcher = all(:css, "a[href='#{path_to(page_name)}']")
-  expect(matcher.count).to be > 0
+  expect(matcher.count.positive?).to eq true
 end
 
-Then(/^(?:|I )should not see a link to (.+)$/) do |page_name|  
+Then(/^(?:|I )should not see a link to (.+)$/) do |page_name|
   matcher = all(:css, "a[href='#{path_to(page_name)}']")
   expect(matcher.count).to eq 0
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -31,6 +31,9 @@ module NavigationHelpers
       
     when /client referral/
       new_client_referrers_path
+    
+    when /dashboard/
+      advisor_dashboard_index_path
 
     else
       begin

--- a/spec/controllers/hubs_controller_spec.rb
+++ b/spec/controllers/hubs_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe HubsController, type: :controller do
     
     let!(:hubs) do
       Fabricate.times(5, :hub) do
-        advisors(count: 1) { Fabricate(:advisor_without_hub, team_leader: true) }
+        advisors(count: 1) { Fabricate(:advisor_without_hub, role: :team_leader) }
       end
     end
     

--- a/spec/models/advisor_spec.rb
+++ b/spec/models/advisor_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Advisor, type: :model do
       expect(subject.default_hub_id).to eq(subject.hub_id)
     end
     
-    it 'returns nil if show_all_hubs is true' do
-      subject.options['show_all_hubs'] = true
+    it 'returns if a user is an admin' do
+      subject.role = :admin
       expect(subject.default_hub_id).to eq(nil)
     end
     

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe Client, type: :model do
       end
       
       it 'gets clients for a hub' do
-        expect(Client.by_hub_id(hub1.id)).to eq(hub1_clients)
-        expect(Client.by_hub_id(hub2.id)).to eq(hub2_clients)
+        expect(Client.by_hub_id(hub1.id)).to match_array(hub1_clients)
+        expect(Client.by_hub_id(hub2.id)).to match_array(hub2_clients)
       end
       
     end
@@ -130,11 +130,11 @@ RSpec.describe Client, type: :model do
       let!(:old_clients) { Fabricate.times(5, :client, created_at: old_date) }
       
       it 'gets clients registered this month' do
-        expect(Client.registered_on(Time.zone.now)).to eq(new_clients)
+        expect(Client.registered_on(Time.zone.now)).to match_array(new_clients)
       end
       
       it 'gets clients registered last month' do
-        expect(Client.registered_on(1.month.ago)).to eq(old_clients)
+        expect(Client.registered_on(1.month.ago)).to match_array(old_clients)
       end
       
       it 'gets clients registered within a date range' do

--- a/test/fabricators/advisor_fabricator.rb
+++ b/test/fabricators/advisor_fabricator.rb
@@ -9,5 +9,5 @@ Fabricator(:advisor_without_hub, from: :advisor) do
 end
 
 Fabricator(:team_leader, from: :advisor) do
-  team_leader true
+  role :team_leader
 end


### PR DESCRIPTION
This adds a role for employer engagement, and tidies up some of the work around roles. It also makes sure roles who are outside the Hackney Works team don't see things that might be irrelevant / confusing.