### PR TITLE
Improve archive options

### DIFF
--- a/app/controllers/advisor/clients_controller.rb
+++ b/app/controllers/advisor/clients_controller.rb
@@ -110,8 +110,7 @@ class Advisor::ClientsController < Advisor::BaseController # rubocop:disable Cla
       by_age: [['Under 25', true]],
       by_objective: ObjectiveOption.options_for_select,
       by_rag_status: [['Red', :red], ['Amber', :amber], ['Green', :green]],
-      include_archived: [['Include', true]]
-
+      archived: [['Archived', :archived], ['All', :all]]
     }
   end
 

--- a/app/controllers/advisor/my_clients_controller.rb
+++ b/app/controllers/advisor/my_clients_controller.rb
@@ -26,7 +26,7 @@ class Advisor::MyClientsController < Advisor::BaseController
       by_types_of_work: TypeOfWorkOption.options_for_select,
       by_training: TrainingCourseOption.options_for_select,
       by_age: [['Under 25', :under_25s]],
-      include_archived: [['Include', true]]
+      archived: [['Archived', :archived], ['All', :all]]
     }
   end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -66,7 +66,7 @@ class Client < ApplicationRecord # rubocop:disable ClassLength
       by_advisor_id
       by_training
       by_age
-      include_archived
+      archived
       by_rag_status
       by_objective
       sorted_by
@@ -96,8 +96,14 @@ class Client < ApplicationRecord # rubocop:disable ClassLength
     where('date_of_birth  > ?', Time.zone.today - 25.years) if under_25s
   }
 
-  scope :include_archived, lambda { |include_archived|
-    with_deleted if include_archived
+  scope :archived, lambda { |state|
+    if state == 'archived'
+      only_deleted
+    elsif state == 'all'
+      with_deleted
+    else
+      all
+    end
   }
 
   pg_search_scope :search_query, against: %i[first_name last_name], using: {

--- a/app/views/advisor/clients/index.html.haml
+++ b/app/views/advisor/clients/index.html.haml
@@ -49,9 +49,9 @@
             = f.select(:by_rag_status, @filterrific.select_options[:by_rag_status], { include_blank: '- Any -' })
 
         .column
-          %label.label Archived
+          %label.label Archived state
           %span.select
-            = f.select(:include_archived, @filterrific.select_options[:include_archived], { include_blank: '- Filtered -' })
+            = f.select(:archived, @filterrific.select_options[:archived], { include_blank: 'Non-archived' })
 
         .column.has-text-right#fix-line-hieght-dbl
           = f.button :surpress_cv_download_on_pressing_enter_ugh!, class: 'is-hidden'

--- a/app/views/advisor/my_clients/index.html.haml
+++ b/app/views/advisor/my_clients/index.html.haml
@@ -65,7 +65,7 @@
           .column
             %label.label Archived
             %span.select
-              = f.select(:include_archived, @filterrific.select_options[:include_archived], { include_blank: '- Filtered -' })
+              = f.select(:archived, @filterrific.select_options[:archived], { include_blank: 'Non-archived' })
 
           .column.has-text-right#fix-line-hieght
             = f.button :surpress_cv_download_on_pressing_enter_ugh!, class: 'is-hidden'

--- a/features/advisors/restores_client.feature
+++ b/features/advisors/restores_client.feature
@@ -11,7 +11,7 @@ Feature: Advisor restores client
   Scenario: Advisor can find archived clients
     Given I am on the advisor clients page
     Then I should not see the client listed
-    When I include archived clients in the results
+    When I am on the advisor archived clients page
     Then I should see the archived client listed
 
   Scenario: Advisor restores archived client

--- a/features/advisors/restores_client.feature
+++ b/features/advisors/restores_client.feature
@@ -8,7 +8,6 @@ Feature: Advisor restores client
     Given I am signed in as an advisor
     And there is a client who has been archived
 
-  @wip
   Scenario: Advisor can find archived clients
     Given I am on the advisor clients page
     Then I should not see the client listed
@@ -17,6 +16,7 @@ Feature: Advisor restores client
 
   Scenario: Advisor restores archived client
     Given I am on the advisor archived clients page
+    And I include archived clients in the results
     When I restore the client to the system
     Then I should be redirected to the client's edit page
     And the client should be restored and found by default

--- a/features/step_definitions/advisor_steps.rb
+++ b/features/step_definitions/advisor_steps.rb
@@ -83,7 +83,7 @@ Given(/^there is an advisor Dave in my hub$/) do
 end
 
 When(/^I include archived clients in the results$/) do
-  select 'Include', from: 'filterrific_include_archived'
+  select 'All', from: 'filterrific_archived'
 end
 
 Then(/^I should see the archived client listed$/) do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -21,7 +21,7 @@ module NavigationHelpers
       advisor_clients_path
 
     when /the advisor archived clients/
-      advisor_clients_path(filterrific: { include_archived: true })
+      advisor_clients_path(filterrific: { archived: 'archived' })
 
     when /the advisors edit client/
       edit_advisor_client_path(@client)


### PR DESCRIPTION
This gives three options for viewing archived clients, 'Non-archived' is the default, advisors can also choose to view all clients, as well as just archived clients.