### PR TITLE
Account settings

### DIFF
--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -46,4 +46,9 @@ class Advisor < ApplicationRecord
     login.send :set_reset_password_token
     login.send_reset_password_instructions
   end
+  
+  def can_assign?(client)
+    return false unless hackney_works_team?
+    client.advisor != self
+  end
 end

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -47,8 +47,12 @@ class Advisor < ApplicationRecord
     login.send_reset_password_instructions
   end
   
-  def can_assign?(client)
+  def can_assign_to_me?(client)
     return false unless hackney_works_team?
     client.advisor != self
+  end
+  
+  def can_assign?
+    team_leader? || admin?
   end
 end

--- a/app/views/advisor/clients/_actions.html.haml
+++ b/app/views/advisor/clients/_actions.html.haml
@@ -6,6 +6,6 @@
         .select
           = form.input :advisor_id, as: :select, collection: Advisor.all, include_blank: false, label: false
         = form.submit I18n.t('clients.buttons.assign_advisor'), class: "step button is-primary"
-      - elsif client.advisor != current_advisor
+      - elsif current_advisor.can_assign?(client)
         = form.input :advisor_id, as: :hidden, input_html: { value: current_advisor.id }
-        = form.submit I18n.t('clients.buttons.assign_to_me'), class: "step button is-primary" if !current_advisor.admin?
+        = form.submit I18n.t('clients.buttons.assign_to_me'), class: "step button is-primary"

--- a/app/views/advisor/clients/_actions.html.haml
+++ b/app/views/advisor/clients/_actions.html.haml
@@ -1,11 +1,11 @@
 .columns
   = simple_form_for client.object, url: advisor_client_path(client_id: client.id) do |form|
     .column
-      - if current_advisor.team_leader?
+      - if current_advisor.can_assign?
         = render 'shared/form_errors', object: form.object
         .select
           = form.input :advisor_id, as: :select, collection: Advisor.all, include_blank: false, label: false
         = form.submit I18n.t('clients.buttons.assign_advisor'), class: "step button is-primary"
-      - elsif current_advisor.can_assign?(client)
+      - elsif current_advisor.can_assign_to_me?(client)
         = form.input :advisor_id, as: :hidden, input_html: { value: current_advisor.id }
         = form.submit I18n.t('clients.buttons.assign_to_me'), class: "step button is-primary"

--- a/features/advisors/takes_on_client.feature
+++ b/features/advisors/takes_on_client.feature
@@ -19,3 +19,9 @@ Feature: Advisor takes on new case
     And I am on the advisor clients page
     When I assign the client to myself
     Then the client should be part of my case load
+  
+  Scenario: Employer engagement can't see assign button
+    Given I am an in the employer engagement team
+    And I have signed in
+    And I am on the advisor clients page
+    Then I should not be able to see the assign to me button

--- a/features/step_definitions/advisor_steps.rb
+++ b/features/step_definitions/advisor_steps.rb
@@ -76,6 +76,11 @@ When(/^I assign the client to myself$/) do
   click_on I18n.t('clients.buttons.assign_to_me')
 end
 
+Then(/^I should not be able to see the assign to me button$/) do
+  click_on 'View details'
+  expect(page).to_not have_content(I18n.t('clients.buttons.assign_to_me'))
+end
+
 Then(/^the client should be part of my case load$/) do
   expect(@i.reload.clients).to include(@client)
   visit advisor_my_clients_path

--- a/features/team_leaders/assign_client_to_advisor.feature
+++ b/features/team_leaders/assign_client_to_advisor.feature
@@ -10,7 +10,13 @@ Feature: Team leader assigns client to another Advisor
     When I navigate to see the client's details
     Then I should see that the client is assigned to me
     And I should be able to assign the client to Dave
-
+    
+  Scenario: Admin is able to assign client
+    Given I am signed in as an admin
+    And I am on the advisor clients page
+    When I navigate to see the client's details
+    Then I should be able to assign the client to Dave
+    
   Scenario: Advisor assigns client
     Given I am on the advisors edit client page
     When I assign the client to dave


### PR DESCRIPTION
* Remove 'assign to me' button from Employer Engagement accounts
* Admin should be able to assign and reassign clients.