### PR TITLE
Remove the Supported Employment section from register screen

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -60,7 +60,6 @@ class ClientsController < ApplicationController
       :address_line_1,
       :address_line_2,
       :postcode,
-      :assigned_supported_employment,
       :wants_advisor,
       login_attributes: [:email],
       assessment_notes_attributes: %i[

--- a/app/views/clients/new.html.haml
+++ b/app/views/clients/new.html.haml
@@ -24,13 +24,5 @@
         #want_advisor.convert_radio
           = form.input :wants_advisor, as: :radio_buttons, collection: [['Yes', true], ['No', false]], label: "Would you like to be assigned to a Hackney Works advisor?"
 
-      %hr
-      #supportedemployment_block
-        %p.bold Supported Employment
-        %p If you need support with your mental health condition or have a learning disability, please tick the box below.
-
-        .inline_checkbox.light-label
-          = form.input :assigned_supported_employment, as: :boolean, label: "Tick here if you would like to see one of these advisors."
-
       %br
       = form.submit t('devise.buttons.register'), :class => 'button is-primary is-pulled-right is-large'


### PR DESCRIPTION
There is a need to remove the Supported Employment section from [Hackney Works](https://app.opportunities.hackney.gov.uk/clients/new)  as this is no longer needed.

Before:
<img width="1189" alt="Screenshot 2023-10-09 at 13 46 10" src="https://github.com/LBHackney-IT/ways-into-work/assets/40758489/420bf9dd-8918-42fd-a2d5-6398cf6093bb">


After:
<img width="1285" alt="Screenshot 2023-10-09 at 13 45 37" src="https://github.com/LBHackney-IT/ways-into-work/assets/40758489/e5f3bea0-fc91-47de-b03e-52c70eff0770">
